### PR TITLE
Fixed maven shade plugin config to account for signed JARs

### DIFF
--- a/CCMobileSwitcher.bat
+++ b/CCMobileSwitcher.bat
@@ -1,0 +1,1 @@
+java -jar CCMobileSwitcher-1.1.1-shaded.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.femtopedia</groupId>
@@ -72,6 +70,16 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <finalName>${finalName}</finalName>
                     <createDependencyReducedPom>false
                     </createDependencyReducedPom>

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: de.femtopedia.ccmobileswitcher.Main
+


### PR DESCRIPTION
The META-INF can be ignored since IntelliJ being dumb. Running "mvn package" builds a functional JAR that runs fine as long as the batch file I made is in the same directory.